### PR TITLE
feat: add multi analytics database routing for SQL and introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,10 @@ python -m dash  # CLI mode
 |----------|----------|-------------|
 | `OPENAI_API_KEY` | Yes | OpenAI API key |
 | `EXA_API_KEY` | No | Web search for external knowledge |
-| `DB_*` | No | Database config (defaults to localhost) |
+| `DB_*` | No | Internal Dash DB config for knowledge/learnings/AgentOS |
+| `ANALYTICS_DB_*` | No | Optional analytics DB URLs (`ANALYTICS_DB_<NAME>`) and descriptions (`ANALYTICS_DB_<NAME>_DESC`) |
+
+If no `ANALYTICS_DB_*` variables are set, Dash keeps original single-database behavior and uses the internal DB as analytics source.
 
 ## Further Reading
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,5 @@
 services:
+  # Internal database used by Dash for knowledge, learnings, and AgentOS state.
   dash-db:
     image: agnohq/pgvector:18
     container_name: dash-db
@@ -31,11 +32,16 @@ services:
       DATA_DIR: /data
       RUNTIME_ENV: dev
       AGNO_DEBUG: "True"
+      # Internal Dash DB (knowledge, learnings, AgentOS)
       DB_HOST: dash-db
       DB_PORT: 5432
       DB_USER: ${DB_USER:-ai}
       DB_PASS: ${DB_PASS:-ai}
       DB_DATABASE: ${DB_DATABASE:-ai}
+      # Optional analytics DBs (read-only by credentials):
+      # ANALYTICS_DB_MAIN=postgresql+psycopg://user:pass@host:5432/dbname
+      # ANALYTICS_DB_MAIN_DESC=F1 sample data
+      # If ANALYTICS_DB_* is not set, Dash uses the internal DB as the single analytics source.
       WAIT_FOR_DB: "True"
       PRINT_ENV_ON_LOAD: "True"
       OPENAI_API_KEY: ${OPENAI_API_KEY}

--- a/dash/context/business_rules.py
+++ b/dash/context/business_rules.py
@@ -42,6 +42,8 @@ def build_business_context(business_dir: Path | None = None) -> str:
         lines.append("## METRICS\n")
         for m in business["metrics"]:
             lines.append(f"**{m.get('name', 'Unknown')}**: {m.get('definition', '')}")
+            if m.get("database"):
+                lines.append(f"  - Database: `{m['database']}`")
             if m.get("table"):
                 lines.append(f"  - Table: `{m['table']}`")
             if m.get("calculation"):

--- a/dash/context/semantic_model.py
+++ b/dash/context/semantic_model.py
@@ -30,6 +30,7 @@ def load_table_metadata(tables_dir: Path | None = None) -> list[dict[str, Any]]:
                     "description": table.get("table_description", ""),
                     "use_cases": table.get("use_cases", []),
                     "data_quality_notes": table.get("data_quality_notes", [])[:MAX_QUALITY_NOTES],
+                    "database": table.get("database"),
                 }
             )
         except (json.JSONDecodeError, KeyError, OSError) as e:
@@ -45,9 +46,32 @@ def build_semantic_model(tables_dir: Path | None = None) -> dict[str, Any]:
 
 def format_semantic_model(model: dict[str, Any]) -> str:
     """Format semantic model for system prompt."""
+    tables = model.get("tables", [])
+    if not tables:
+        return ""
+
+    grouped: dict[str | None, list[dict[str, Any]]] = {}
+    for table in tables:
+        grouped.setdefault(table.get("database"), []).append(table)
+
     lines: list[str] = []
 
-    for table in model.get("tables", []):
+    for database in sorted(key for key in grouped if key is not None):
+        lines.append(f"### Database: **{database}**")
+        lines.append("")
+        for table in grouped[database]:
+            lines.append(f"#### {table['table_name']}")
+            if table.get("description"):
+                lines.append(table["description"])
+            if table.get("use_cases"):
+                lines.append(f"**Use cases:** {', '.join(table['use_cases'])}")
+            if table.get("data_quality_notes"):
+                lines.append("**Data quality:**")
+                for note in table["data_quality_notes"]:
+                    lines.append(f"  - {note}")
+            lines.append("")
+
+    for table in grouped.get(None, []):
         lines.append(f"### {table['table_name']}")
         if table.get("description"):
             lines.append(table["description"])

--- a/dash/knowledge/business/metrics.json
+++ b/dash/knowledge/business/metrics.json
@@ -1,48 +1,56 @@
 {
   "metrics": [
     {
+      "database": "main",
       "name": "Race Win",
       "definition": "A driver finishing in first position in a race",
       "table": "race_wins",
       "calculation": "COUNT(*) from race_wins grouped by driver name"
     },
     {
+      "database": "main",
       "name": "World Championship",
       "definition": "A driver finishing the season in first position in the drivers championship",
       "table": "drivers_championship",
       "calculation": "COUNT(*) from drivers_championship WHERE position = '1' (TEXT comparison)"
     },
     {
+      "database": "main",
       "name": "Constructors Championship",
       "definition": "A team finishing the season in first position in the constructors championship",
       "table": "constructors_championship",
       "calculation": "COUNT(*) from constructors_championship WHERE position = 1 (INTEGER comparison)"
     },
     {
+      "database": "main",
       "name": "Podium Finish",
       "definition": "A driver finishing in positions 1, 2, or 3 in a race",
       "table": "race_results",
       "calculation": "COUNT(*) from race_results WHERE position IN ('1', '2', '3')"
     },
     {
+      "database": "main",
       "name": "Fastest Lap",
       "definition": "Recording the fastest lap time during a race",
       "table": "fastest_laps",
       "calculation": "COUNT(*) from fastest_laps grouped by driver name"
     },
     {
+      "database": "main",
       "name": "DNF (Did Not Finish)",
       "definition": "A driver who retired from a race before completion",
       "table": "race_results",
       "calculation": "COUNT(*) from race_results WHERE position = 'Ret'"
     },
     {
+      "database": "main",
       "name": "Points Finish",
       "definition": "A driver finishing in a points-scoring position",
       "table": "race_results",
       "calculation": "COUNT(*) from race_results WHERE points > 0"
     },
     {
+      "database": "main",
       "name": "Championship Points",
       "definition": "Total points accumulated over a season",
       "table": "drivers_championship or constructors_championship",

--- a/dash/knowledge/tables/constructors_championship.json
+++ b/dash/knowledge/tables/constructors_championship.json
@@ -1,4 +1,5 @@
 {
+  "database": "main",
   "table_name": "constructors_championship",
   "table_description": "Contains data for the constructor's championship from 1958 to 2020, capturing championship positions from when it was introduced.",
   "use_cases": [

--- a/dash/knowledge/tables/drivers_championship.json
+++ b/dash/knowledge/tables/drivers_championship.json
@@ -1,4 +1,5 @@
 {
+  "database": "main",
   "table_name": "drivers_championship",
   "table_description": "Contains data for driver's championship standings from 1950-2020, detailing driver positions, teams, and points.",
   "use_cases": [

--- a/dash/knowledge/tables/fastest_laps.json
+++ b/dash/knowledge/tables/fastest_laps.json
@@ -1,4 +1,5 @@
 {
+  "database": "main",
   "table_name": "fastest_laps",
   "table_description": "Contains data for the fastest laps recorded in races from 1950-2020, including driver and team details.",
   "use_cases": [

--- a/dash/knowledge/tables/race_results.json
+++ b/dash/knowledge/tables/race_results.json
@@ -1,4 +1,5 @@
 {
+  "database": "main",
   "table_name": "race_results",
   "table_description": "Holds comprehensive race data for each Formula 1 race from 1950-2020, including positions, drivers, teams, and points.",
   "use_cases": [

--- a/dash/knowledge/tables/race_wins.json
+++ b/dash/knowledge/tables/race_wins.json
@@ -1,4 +1,5 @@
 {
+  "database": "main",
   "table_name": "race_wins",
   "table_description": "Documents race win data from 1950-2020, detailing venue, winner, team, and race duration.",
   "use_cases": [

--- a/dash/tools/__init__.py
+++ b/dash/tools/__init__.py
@@ -2,8 +2,10 @@
 
 from dash.tools.introspect import create_introspect_schema_tool
 from dash.tools.save_query import create_save_validated_query_tool
+from dash.tools.sql import create_analytics_sql_tools
 
 __all__ = [
+    "create_analytics_sql_tools",
     "create_introspect_schema_tool",
     "create_save_validated_query_tool",
 ]

--- a/dash/tools/introspect.py
+++ b/dash/tools/introspect.py
@@ -26,6 +26,12 @@ def create_introspect_schema_tool(registry: dict[str, str]):
             )
 
         name = database.strip().lower()
+        if not name:
+            available = ", ".join(db_names)
+            raise ValueError(
+                "Multiple analytics databases configured. "
+                f"Pass `database`. Available: {available}"
+            )
         if name not in engines:
             available = ", ".join(db_names)
             raise ValueError(f"Unknown database '{name}'. Available: {available}")

--- a/dash/tools/sql.py
+++ b/dash/tools/sql.py
@@ -23,6 +23,12 @@ def create_analytics_sql_tools(registry: dict[str, str]) -> list:
             )
 
         name = database.strip().lower()
+        if not name:
+            available = ", ".join(db_names)
+            raise ValueError(
+                "Multiple analytics databases configured. "
+                f"Pass `database`. Available: {available}"
+            )
         if name not in sql_tools_by_db:
             available = ", ".join(db_names)
             raise ValueError(f"Unknown database '{name}'. Available: {available}")

--- a/dash/tools/sql.py
+++ b/dash/tools/sql.py
@@ -1,0 +1,63 @@
+"""Analytics SQL tools with logical database routing."""
+
+from agno.tools import tool
+from agno.tools.sql import SQLTools
+
+
+def create_analytics_sql_tools(registry: dict[str, str]) -> list:
+    """Create routed SQL tools for one or more analytics databases."""
+    sql_tools_by_db = {name: SQLTools(db_url=url) for name, url in registry.items()}
+    db_names = sorted(sql_tools_by_db)
+    is_single_db = len(sql_tools_by_db) == 1
+    default_db_name = db_names[0] if is_single_db else None
+
+    def _resolve_database_name(database: str | None) -> str:
+        if is_single_db and default_db_name is not None:
+            return default_db_name
+
+        if not database:
+            available = ", ".join(db_names)
+            raise ValueError(
+                "Multiple analytics databases configured. "
+                f"Pass `database`. Available: {available}"
+            )
+
+        name = database.strip().lower()
+        if name not in sql_tools_by_db:
+            available = ", ".join(db_names)
+            raise ValueError(f"Unknown database '{name}'. Available: {available}")
+        return name
+
+    @tool
+    def list_tables(database: str | None = None) -> str:
+        """List all tables in an analytics database.
+
+        Args:
+            database: Logical database name. Optional in single-DB mode.
+        """
+        target_db = _resolve_database_name(database)
+        return sql_tools_by_db[target_db].list_tables()
+
+    @tool
+    def describe_table(table_name: str, database: str | None = None) -> str:
+        """Describe a table in an analytics database.
+
+        Args:
+            table_name: Name of table to describe.
+            database: Logical database name. Optional in single-DB mode.
+        """
+        target_db = _resolve_database_name(database)
+        return sql_tools_by_db[target_db].describe_table(table_name)
+
+    @tool
+    def run_sql_query(query: str, database: str | None = None) -> str:
+        """Run a SQL query in an analytics database.
+
+        Args:
+            query: SQL query to execute.
+            database: Logical database name. Optional in single-DB mode.
+        """
+        target_db = _resolve_database_name(database)
+        return sql_tools_by_db[target_db].run_sql_query(query)
+
+    return [list_tables, describe_table, run_sql_query]

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -5,10 +5,20 @@ Database Module
 Database connection utilities.
 """
 
+from db.config import (
+    get_analytics_descriptions,
+    get_analytics_registry,
+    get_internal_db_url,
+    has_explicit_analytics_dbs,
+)
 from db.session import get_postgres_db
 from db.url import db_url
 
 __all__ = [
     "db_url",
+    "get_analytics_descriptions",
+    "get_analytics_registry",
+    "get_internal_db_url",
     "get_postgres_db",
+    "has_explicit_analytics_dbs",
 ]

--- a/db/config.py
+++ b/db/config.py
@@ -1,0 +1,72 @@
+"""Database configuration: internal DB and optional analytics registries."""
+
+import os
+
+from db.url import db_url as internal_db_url
+
+ANALYTICS_PREFIX = "ANALYTICS_DB_"
+ANALYTICS_DESC_SUFFIX = "_DESC"
+IMPLICIT_DEFAULT_NAME = "default"
+
+
+def _normalize_name(name: str) -> str:
+    return name.strip().lower()
+
+
+def _iter_explicit_analytics_entries() -> list[tuple[str, str]]:
+    """Return explicit ANALYTICS_DB_<NAME>=<url> entries from env vars."""
+    entries: list[tuple[str, str]] = []
+    for key, value in os.environ.items():
+        if not key.startswith(ANALYTICS_PREFIX) or not value:
+            continue
+        if key.endswith(ANALYTICS_DESC_SUFFIX):
+            continue
+
+        raw_name = key[len(ANALYTICS_PREFIX) :]
+        name = _normalize_name(raw_name)
+        if not name:
+            continue
+        entries.append((name, value))
+    return entries
+
+
+def get_internal_db_url() -> str:
+    """Internal DB URL used by Dash for knowledge/learnings/AgentOS."""
+    return internal_db_url
+
+
+def has_explicit_analytics_dbs() -> bool:
+    """True when at least one ANALYTICS_DB_<NAME> URL is configured."""
+    return bool(_iter_explicit_analytics_entries())
+
+
+def get_analytics_registry() -> dict[str, str]:
+    """Return analytics DB registry by logical name.
+
+    Behavior:
+    - If explicit ANALYTICS_DB_<NAME> variables exist, return those.
+    - If none exist, fall back to a single implicit entry to internal DB.
+    """
+    registry = dict(_iter_explicit_analytics_entries())
+    if registry:
+        return registry
+    return {IMPLICIT_DEFAULT_NAME: internal_db_url}
+
+
+def get_analytics_descriptions() -> dict[str, str]:
+    """Return optional ANALYTICS_DB_<NAME>_DESC descriptions by name."""
+    descriptions: dict[str, str] = {}
+    for key, value in os.environ.items():
+        if (
+            not key.startswith(ANALYTICS_PREFIX)
+            or not key.endswith(ANALYTICS_DESC_SUFFIX)
+            or not value
+        ):
+            continue
+
+        raw_name = key[len(ANALYTICS_PREFIX) : -len(ANALYTICS_DESC_SUFFIX)]
+        name = _normalize_name(raw_name)
+        if not name:
+            continue
+        descriptions[name] = value
+    return descriptions

--- a/example.env
+++ b/example.env
@@ -8,7 +8,12 @@ OPENAI_API_KEY=sk-***
 # Exa API key for web research
 # EXA_API_KEY=***
 
-# Database (defaults work out of the box)
+# Internal Dash database (knowledge, learnings, AgentOS). Defaults work out of the box.
 # DB_USER=ai
 # DB_PASS=ai
 # DB_DATABASE=ai
+
+# Optional analytics database(s), read-only.
+# If ANALYTICS_DB_* is not set, Dash falls back to the internal DB as a single analytics source.
+# ANALYTICS_DB_MAIN=postgresql+psycopg://user:pass@host:5432/dbname
+# ANALYTICS_DB_MAIN_DESC=F1 sample data


### PR DESCRIPTION
## Summary
This PR adds optional analytics database routing for SQL and schema introspection while preserving original behavior when no analytics env vars are configured.

## What changed
- Added `db/config.py` with:
  - `get_internal_db_url()`
  - `get_analytics_registry()`
  - `get_analytics_descriptions()`
  - `has_explicit_analytics_dbs()`
- Added routed analytics SQL tools in `dash/tools/sql.py`.
- Updated `dash/tools/introspect.py` to use the same routing model.
- Updated `dash/agents.py` wiring:
  - internal DB remains for knowledge/learnings/AgentOS
  - SQL and introspection tools use analytics registry
  - `AVAILABLE DATABASES` section is shown only when explicit analytics DBs are configured
- Added optional `database` metadata handling in semantic/business context and bundled F1 metadata JSON.
- Updated `dash/scripts/load_data.py` routing behavior:
  - single DB: routes to sole DB
  - multi DB: requires valid `--database`
- Minimal docs updates in `README.md`, `compose.yaml`, and `example.env`.

## Behavior and compatibility
- Backward compatible default path:
  - If no `ANALYTICS_DB_*` vars are set, Dash behaves as single-DB mode and uses internal `DB_*` DB as analytics source.
- Multi-DB mode:
  - `database` is required for SQL/introspection tool calls.
  
- DB_* variables are for Dash’s internal database only (knowledge, learnings, and AgentOS state).
  Analytics query targets are configured separately with ANALYTICS_DB_<NAME>=<sqlalchemy_url> and optional ANALYTICS_DB_<NAME>_DESC=<human description>.

  Examples:

  - ANALYTICS_DB_MAIN=postgresql+psycopg://user:pass@host:5432/f1
  - ANALYTICS_DB_SALES=postgresql+psycopg://user:pass@host:5432/sales
  - ANALYTICS_DB_MAIN_DESC=F1 historical dataset

  Behavior:

  - If no ANALYTICS_DB_* variables are set, Dash stays backward-compatible and uses the internal DB_* database as a single analytics source.
  - If multiple analytics DBs are configured, tool calls should pass the database argument with the logical name (e.g., main, sales).



## Security model
- No app-layer SQL write guard.
- Read-only safety is expected to be enforced by analytics DB credentials/permissions.
