### PR TITLE
feat: add OpenAI-first provider selection with OpenRouter fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Inspired by [OpenAI's in-house data agent](https://openai.com/index/inside-our-i
 ```sh
 # Clone this repo
 git clone https://github.com/agno-agi/dash.git && cd dash
-# Add OPENAI_API_KEY by adding to .env file or export OPENAI_API_KEY=sk-***
+# Add OPENAI_API_KEY (preferred) or OPENROUTER_API_KEY (fallback) to .env
 cp example.env .env
 
 # Start the application
@@ -234,9 +234,13 @@ python -m dash  # CLI mode
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `OPENAI_API_KEY` | Yes | OpenAI API key |
+| `OPENAI_API_KEY` | Preferred | OpenAI API key (original behavior, highest priority) |
+| `OPENROUTER_API_KEY` | Fallback | Used only when `OPENAI_API_KEY` is not set |
+| `DASH_MODEL` | No | Model override for OpenRouter path (default: `openai/gpt-4o`) |
 | `EXA_API_KEY` | No | Web search for external knowledge |
 | `DB_*` | No | Database config (defaults to localhost) |
+
+Provider priority: Dash uses OpenAI when `OPENAI_API_KEY` is set. If it is not set and `OPENROUTER_API_KEY` is set, Dash uses OpenRouter.
 
 ## Further Reading
 

--- a/example.env
+++ b/example.env
@@ -1,9 +1,11 @@
-# Required (default configured for OpenAI)
+# Preferred (original behavior): OpenAI key
 OPENAI_API_KEY=sk-***
 
-# Optional: Use a different model provider
-# ANTHROPIC_API_KEY=sk-ant-***
-# GOOGLE_API_KEY=***
+# Optional fallback provider: used only when OPENAI_API_KEY is not set
+# OPENROUTER_API_KEY=sk-or-v1-***
+
+# Optional model override (OpenRouter path only, default: openai/gpt-4o)
+# DASH_MODEL=openai/gpt-4o
 
 # Exa API key for web research
 # EXA_API_KEY=***


### PR DESCRIPTION
## Summary
This PR adds provider selection that preserves original OpenAI behavior and uses OpenRouter only as fallback.

## Behavior
- If `OPENAI_API_KEY` is set: Dash uses OpenAI model + OpenAI embedding path (original behavior).
- Else if `OPENROUTER_API_KEY` is set: Dash uses OpenRouter model + OpenRouter-backed embedding path.
- If both are set: OpenAI takes priority.
- If neither is set: current failure behavior is unchanged.

## Changes
- `dash/agents.py`
  - Added provider selection logic (OpenAI first, OpenRouter fallback).
  - Added OpenRouter model/embedding configuration for fallback path only.
- `example.env`
  - Documented key priority and fallback behavior.
- `README.md`
  - Updated env docs and quick-start note for key priority.

## Scope control
Included only runtime/docs for provider fallback.

Not included:
- `.gitlab-ci.yml`
- `compose.yaml`
- deployment/infrastructure changes
- analytics-db related changes

## Validation
- `python -m compileall dash db app`
- Manual sanity checks for key matrix:
  - OpenAI only -> OpenAI path
  - OpenRouter only -> OpenRouter path
  - both -> OpenAI path