### PR TITLE
docs: update Slack setup with production flow and event verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ See [docs/SLACK_CONNECT.md](docs/SLACK_CONNECT.md) for the full setup guide with
 **Local development**: use [ngrok](https://ngrok.com/download/mac-os) to get a public URL:
 
 ```sh
+# Docker Compose (Quick Start)
+ngrok http 8000
+
+# Bare AgentOS (python -m app.main)
 ngrok http 7777
 ```
 

--- a/README.md
+++ b/README.md
@@ -151,76 +151,15 @@ Dockerfile, Docker Compose, one-command deployment. Scheduled tasks for proactiv
 
 ## Slack
 
-Slack gives Dash two capabilities: receiving messages from users in Slack threads, and proactively posting to channels.
+Dash can receive Slack DMs, @mentions, and thread replies, and can also post to channels proactively.
 
-See [docs/SLACK_CONNECT.md](docs/SLACK_CONNECT.md) for the full setup guide with the app manifest.
+Quick setup:
+1. Run Dash and give it a public URL (ngrok locally, or your Railway domain).
+2. Follow [docs/SLACK_CONNECT.md](docs/SLACK_CONNECT.md) to create and install the Slack app from the manifest.
+3. Set `SLACK_TOKEN` and `SLACK_SIGNING_SECRET`, then restart Dash.
+4. In Slack, confirm Event Subscriptions is verified and send a DM or `@mention` to test it.
 
-### 1. Get your URL
-
-**Production** (Railway or other host): use your deployed URL (e.g. `https://dash-production-xxxx.up.railway.app`).
-
-**Local development**: use [ngrok](https://ngrok.com/download/mac-os) to get a public URL:
-
-```sh
-# Docker Compose (Quick Start)
-ngrok http 8000
-
-# Bare AgentOS (python -m app.main)
-ngrok http 7777
-```
-
-Copy the `https://` URL (e.g. `https://abc123.ngrok-free.app`).
-
-### 2. Create app from manifest
-
-1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App → From a manifest**
-2. Select your workspace, switch to **JSON**
-3. Paste the manifest from [docs/SLACK_CONNECT.md](docs/SLACK_CONNECT.md) — replace `YOUR_URL_HERE` with your URL
-4. Click **Create**
-
-### 3. Install and get credentials
-
-1. **Install to Workspace** and authorize
-2. Copy **Bot User OAuth Token** (`xoxb-...`) → `SLACK_TOKEN`
-3. Go to **Basic Information → App Credentials**, copy **Signing Secret** → `SLACK_SIGNING_SECRET`
-
-### 4. Add credentials and restart
-
-**Local development:**
-
-```env
-SLACK_TOKEN="xoxb-your-bot-token"
-SLACK_SIGNING_SECRET="your-signing-secret"
-```
-
-```sh
-docker compose up -d --build
-```
-
-**Railway:**
-
-```sh
-# Add to .env.production, then sync and redeploy
-./scripts/railway_env.sh
-./scripts/railway_redeploy.sh
-```
-
-### 5. Verify Event Subscriptions
-
-Slack verifies your endpoint with a `challenge` request when the app is created. If your server wasn't running at that time, the verification fails and events won't be delivered.
-
-1. Go to [api.slack.com/apps](https://api.slack.com/apps) → your Dash app → **Event Subscriptions**
-2. If the Request URL shows "Your URL didn't respond", click **Retry**
-3. Confirm it shows **Verified** with a green checkmark
-4. Click **Save Changes**
-
-### 6. Test
-
-- **@mention** Dash in any channel it's been added to: `@Dash What's our MRR?`
-- **DM** the Dash bot directly
-- **Thread replies** continue the conversation with full context
-
-Thread timestamps map to session IDs, so each Slack thread gets its own conversation context.
+Each Slack thread maps to one Dash session. For the manifest, ngrok commands, Railway deployment, permissions, and troubleshooting, see [docs/SLACK_CONNECT.md](docs/SLACK_CONNECT.md).
 
 ## Data Model (SaaS Metrics)
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,14 @@ Slack gives Dash two capabilities: receiving messages from users in Slack thread
 
 See [docs/SLACK_CONNECT.md](docs/SLACK_CONNECT.md) for the full setup guide with the app manifest.
 
-### 1. Get a public URL
+### 1. Get your URL
 
-For local development, use [ngrok](https://ngrok.com/download/mac-os):
+**Production** (Railway or other host): use your deployed URL (e.g. `https://dash-production-xxxx.up.railway.app`).
+
+**Local development**: use [ngrok](https://ngrok.com/download/mac-os) to get a public URL:
 
 ```sh
-ngrok http 8000
+ngrok http 7777
 ```
 
 Copy the `https://` URL (e.g. `https://abc123.ngrok-free.app`).
@@ -178,7 +180,9 @@ Copy the `https://` URL (e.g. `https://abc123.ngrok-free.app`).
 2. Copy **Bot User OAuth Token** (`xoxb-...`) → `SLACK_TOKEN`
 3. Go to **Basic Information → App Credentials**, copy **Signing Secret** → `SLACK_SIGNING_SECRET`
 
-### 4. Add to `.env` and restart
+### 4. Add credentials and restart
+
+**Local development:**
 
 ```env
 SLACK_TOKEN="xoxb-your-bot-token"
@@ -189,11 +193,34 @@ SLACK_SIGNING_SECRET="your-signing-secret"
 docker compose up -d --build
 ```
 
+**Railway:**
+
+```sh
+# Add to .env.production, then sync and redeploy
+./scripts/railway_env.sh
+./scripts/railway_redeploy.sh
+```
+
+### 5. Verify Event Subscriptions
+
+Slack verifies your endpoint with a `challenge` request when the app is created. If your server wasn't running at that time, the verification fails and events won't be delivered.
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → your Dash app → **Event Subscriptions**
+2. If the Request URL shows "Your URL didn't respond", click **Retry**
+3. Confirm it shows **Verified** with a green checkmark
+4. Click **Save Changes**
+
+### 6. Test
+
+- **@mention** Dash in any channel it's been added to: `@Dash What's our MRR?`
+- **DM** the Dash bot directly
+- **Thread replies** continue the conversation with full context
+
 Thread timestamps map to session IDs, so each Slack thread gets its own conversation context.
 
 ## Data Model (SaaS Metrics)
 
-Synthetic B2B SaaS dataset (~500 customers, 2 years of data):
+Synthetic B2B SaaS dataset (~900 customers, 2 years of data):
 
 | Table | Description |
 |-------|-------------|

--- a/docs/SLACK_CONNECT.md
+++ b/docs/SLACK_CONNECT.md
@@ -8,7 +8,7 @@ Each Slack thread maps to a session ID, so every thread gets its own conversatio
 
 ## Prerequisites
 
-- Dash running (locally via `docker compose up -d --build` or deployed to Railway)
+- Dash running locally (`docker compose up -d --build`) or deployed to a public URL
 - A Slack workspace where you can install apps
 
 ## Step 1: Get a Public URL

--- a/docs/SLACK_CONNECT.md
+++ b/docs/SLACK_CONNECT.md
@@ -8,22 +8,26 @@ Each Slack thread maps to a session ID, so every thread gets its own conversatio
 
 ## Prerequisites
 
-- Dash running locally (`docker compose up -d --build`)
+- Dash running (locally via `docker compose up -d --build` or deployed to Railway)
 - A Slack workspace where you can install apps
 
 ## Step 1: Get a Public URL
 
 Slack needs a public URL to send events to Dash.
 
+**Production** — use your deployed URL (e.g., `https://dash-production-xxxx.up.railway.app`).
+
 **Local development** — use [ngrok](https://ngrok.com/download/mac-os):
 
 ```sh
+# Docker Compose (Quick Start)
 ngrok http 8000
+
+# Bare AgentOS (python -m app.main)
+ngrok http 7777
 ```
 
 Copy the `https://` URL (e.g., `https://abc123.ngrok-free.app`). This is your base URL.
-
-**Production** — use your deployed URL (e.g., `https://dash.example.com`).
 
 ## Step 2: Create a Slack App from Manifest
 
@@ -100,21 +104,39 @@ Copy the `https://` URL (e.g., `https://abc123.ngrok-free.app`). This is your ba
 3. Authorize the requested permissions
 4. Copy the **Bot User OAuth Token** (`xoxb-...`)
 
-## Step 4: Add Credentials to `.env`
+## Step 4: Add Credentials and Restart
 
 1. Copy the bot token from Step 3 → `SLACK_TOKEN`
 2. Go to **Basic Information** in the sidebar, under **App Credentials**, copy **Signing Secret** → `SLACK_SIGNING_SECRET`
+
+**Local development:**
 
 ```env
 SLACK_TOKEN="xoxb-your-bot-token"
 SLACK_SIGNING_SECRET="your-signing-secret"
 ```
 
-## Step 5: Restart Dash
-
 ```sh
 docker compose up -d --build
 ```
+
+**Railway:**
+
+Add both variables to `.env.production`, then sync and redeploy:
+
+```sh
+./scripts/railway_env.sh
+./scripts/railway_redeploy.sh
+```
+
+## Step 5: Verify Event Subscriptions
+
+Slack verifies your endpoint with a `challenge` request when the app is created. If Dash wasn't running at that time, the verification fails silently and events won't be delivered.
+
+1. Go to your Dash app settings → **Event Subscriptions**
+2. If the Request URL shows "Your URL didn't respond", click **Retry**
+3. Confirm it shows **Verified** with a green checkmark
+4. Click **Save Changes**
 
 ## Verify
 


### PR DESCRIPTION
## Summary

- Add production (Railway) deployment instructions alongside local Docker setup
- Add critical **Event Subscriptions verification** step — when the Slack app is created before the server is running, the `challenge` verification fails silently and events never arrive. Step 5 documents the retry fix
- Show both ngrok ports: `8000` for Docker Compose, `7777` for bare AgentOS
- Update `docs/SLACK_CONNECT.md` to match README changes
- Fix customer count: ~900 (was ~500, actual is 888)

## Context

Discovered during Railway deployment of Dash to the Agno workspace. The Slack app was created from manifest before the server had Slack credentials, so the event subscription URL verification failed. Events weren't delivered until we manually retried verification in the Slack app settings.

## Type of change

- [x] Documentation update

## Checklist

- [x] Both `README.md` and `docs/SLACK_CONNECT.md` updated consistently
- [x] Port scoping reviewed (Codex second opinion confirmed Docker=8000, bare=7777)
- [x] `format.sh` and `validate.sh` pass
- [x] Tested E2E: Railway deploy + Slack bot in Agno workspace `#slack-apps-testing` channel