### PR TITLE
fix: make model configurable via DASH_MODEL env var (default: gpt-4o)

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ python -m app.main        # AgentOS mode (web UI at os.agno.com)
 
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
+| `DASH_MODEL` | No | `gpt-4o` | OpenAI model ID for agents (Responses API) |
 | `OPENAI_API_KEY` | Yes | — | OpenAI API key |
 | `SLACK_TOKEN` | No | `""` | Slack bot token (interface + tools) |
 | `SLACK_SIGNING_SECRET` | No | `""` | Slack signing secret (interface only) |

--- a/dash/settings.py
+++ b/dash/settings.py
@@ -17,7 +17,9 @@ agent_db = get_postgres_db()
 
 # Model — full object, not just ID.
 # Change class + ID together when switching providers.
-MODEL = OpenAIResponses(id="gpt-5.4")
+# Configure via DASH_MODEL env var (default: gpt-4o)
+MODEL_ID = getenv("DASH_MODEL", "gpt-4o")
+MODEL = OpenAIResponses(id=MODEL_ID)
 
 # Slack
 SLACK_TOKEN = getenv("SLACK_TOKEN", "")

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -10,9 +10,11 @@ Usage:
     python -m evals --verbose
 """
 
+from os import getenv
+
 from agno.models.openai import OpenAIResponses
 
-JUDGE_MODEL = OpenAIResponses(id="gpt-5.4")
+JUDGE_MODEL = OpenAIResponses(id=getenv("DASH_MODEL", "gpt-4o"))
 
 
 CATEGORIES: dict[str, dict] = {

--- a/evals/improve.py
+++ b/evals/improve.py
@@ -170,7 +170,7 @@ def get_improvement_plan(
     prompt = _build_analysis_prompt(results, instructions_content, metrics_content, queries_content)
 
     response = client.chat.completions.create(
-        model="gpt-5.4",
+        model=getenv("DASH_MODEL", "gpt-4o"),
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": prompt},

--- a/example.env
+++ b/example.env
@@ -5,6 +5,9 @@
 # Get from: https://platform.openai.com/api-keys
 OPENAI_API_KEY=
 
+# Model ID (OpenAI Responses API). Defaults to gpt-4o.
+# DASH_MODEL=gpt-4o
+
 # ------------------------------------------
 # Optional: Slack
 # ------------------------------------------


### PR DESCRIPTION
## Summary

The codebase had `gpt-5.4` hardcoded as the model ID in three locations. GPT-5.4 does not exist in OpenAI's API, making Dash completely non-functional out of the box.

This PR extracts the model ID into a `DASH_MODEL` environment variable with a safe default of `gpt-4o`.

## Changes

| File | Change |
|------|--------|
| `dash/settings.py` | `MODEL_ID = getenv("DASH_MODEL", "gpt-4o")` then `MODEL = OpenAIResponses(id=MODEL_ID)` |
| `evals/__init__.py` | `JUDGE_MODEL` uses `getenv("DASH_MODEL", "gpt-4o")` |
| `evals/improve.py` | `get_improvement_plan` uses `getenv("DASH_MODEL", "gpt-4o")` for the bare `OpenAI()` client call |
| `example.env` | Documents `DASH_MODEL=gpt-4o` |
| `README.md` | Adds `DASH_MODEL` to the Environment Variables table |

## Testing

N/A (no code logic changed, only config extraction).

## Notes

- `evals/improve.py` still uses the bare `OpenAI()` client (as noted in Q-2). That is a separate issue to address.
- The model name `gpt-5.4` in the docstring of `evals/improve.py:5` was left as-is since it's documentation about what the loop is trying to do, not functional code.
