### PR TITLE
ci: use 'uv run mypy' in validate script

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -27,8 +27,8 @@ echo -e "${DIM}> ruff check ${REPO_ROOT}${NC}"
 ruff check ${REPO_ROOT}
 
 echo ""
-echo -e "${DIM}> mypy ${REPO_ROOT} --config-file pyproject.toml${NC}"
-mypy ${REPO_ROOT} --config-file ${REPO_ROOT}/pyproject.toml
+echo -e "${DIM}> uv run mypy ${REPO_ROOT} --config-file pyproject.toml${NC}"
+uv run mypy ${REPO_ROOT} --config-file ${REPO_ROOT}/pyproject.toml
 
 echo ""
 echo -e "${BOLD}Done.${NC}"


### PR DESCRIPTION
## Summary
Fixes the `validate.sh` script to use `uv run mypy` instead of bare `mypy`, ensuring it finds the package-installed version in the uv-managed Python environment.

## Changes
- `scripts/validate.sh`: Replace `mypy` with `uv run mypy` so it correctly resolves the mypy installed in the uv virtual environment.

## Testing
CI validate workflow should pass without "mypy: command not found".
