### PR TITLE
Feat: Add Slack Integration with slack_dash Agent

### DIFF
--- a/app/config.yaml
+++ b/app/config.yaml
@@ -8,3 +8,7 @@ chat:
       - "Tell me about yourself"
       - "Who won the most races in 2019?"
       - "Who won the most F1 World Championships?"
+    slack-dash:
+      - "Tell me about yourself"
+      - "Who won the most races in 2019? Export as CSV"
+      - "Generate an image of a Formula 1 car at Monaco"

--- a/app/main.py
+++ b/app/main.py
@@ -12,8 +12,10 @@ from os import getenv
 from pathlib import Path
 
 from agno.os import AgentOS
+from agno.os.interfaces.slack import Slack
 
 from dash.agents import dash, dash_knowledge, reasoning_dash
+from dash.slack_agent import slack_dash
 from db import get_postgres_db
 
 # ---------------------------------------------------------------------------
@@ -23,9 +25,10 @@ agent_os = AgentOS(
     name="Dash",
     tracing=True,
     db=get_postgres_db(),
-    agents=[dash, reasoning_dash],
+    agents=[dash, reasoning_dash, slack_dash],
     knowledge=[dash_knowledge],
     config=str(Path(__file__).parent / "config.yaml"),
+    interfaces=[Slack(agent=slack_dash, reply_to_mentions_only=True)],
 )
 
 app = agent_os.get_app()

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -1,5 +1,6 @@
 """Dash - A self-learning data agent with 6 layers of context."""
 
 from dash.agents import dash, dash_knowledge, dash_learnings, reasoning_dash
+from dash.slack_agent import slack_dash
 
-__all__ = ["dash", "reasoning_dash", "dash_knowledge", "dash_learnings"]
+__all__ = ["dash", "reasoning_dash", "slack_dash", "dash_knowledge", "dash_learnings"]

--- a/dash/slack_agent.py
+++ b/dash/slack_agent.py
@@ -1,0 +1,61 @@
+"""
+Slack Dash Agent
+================
+
+Enhanced Dash agent with web search, image generation, and file export tools
+for rich Slack interactions.
+
+Run: python -m dash.slack_agent
+"""
+
+from agno.models.openai import OpenAIChat
+from agno.tools.dalle import DalleTools
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.tools.file_generation import FileGenerationTools
+from agno.tools.slack import SlackTools
+
+from dash.agents import INSTRUCTIONS, base_tools, dash
+
+SLACK_INSTRUCTIONS = """\
+
+## Slack Capabilities
+
+You have additional tools for Slack interactions:
+
+**File Export** — When users ask for data exports:
+- Use `generate_csv_file` for tabular data (query results, comparisons)
+- Use `generate_json_file` for structured data
+- Always include descriptive filenames (e.g., "hamilton_2019_wins.csv")
+
+**Image Generation** — When users ask for visualizations or creative images:
+- Use `create_image` to generate images with DALL-E
+- Good for: team logos, race visualizations, infographics
+- Be descriptive in your prompts for best results
+
+**Web Search** — When users ask about recent events or external context:
+- Use `web_search` for current F1 news, driver updates, rule changes
+- Use `search_news` for latest headlines
+- Combine with database queries for comprehensive answers
+
+**Slack** — When asked to share results or notify channels:
+- Use `send_message` to post to channels
+- Use `send_message_thread` to reply in threads
+"""
+
+slack_dash = dash.deep_copy(
+    update={
+        "name": "Slack Dash",
+        "model": OpenAIChat(id="gpt-4o"),
+        "instructions": INSTRUCTIONS + SLACK_INSTRUCTIONS,
+        "tools": base_tools
+        + [
+            DalleTools(),
+            DuckDuckGoTools(),
+            FileGenerationTools(),
+            SlackTools(),
+        ],
+    }
+)
+
+if __name__ == "__main__":
+    slack_dash.print_response("Who won the most races in 2019? Export results as CSV.", stream=True)


### PR DESCRIPTION
# Feat: Add Slack Integration with slack_dash Agent

## Summary
Add Slack integration with a dedicated `slack_dash` agent for handling Slack-based interactions.

## Changes
- Added slack_dash agent implementation
- Integrated Slack tools and configuration

## Testing
Tested locally with Slack webhook integration.
