### PR TITLE
fix: show falsy sample values instead of NULL in introspect_schema

### DIFF
--- a/dash/tools/introspect.py
+++ b/dash/tools/introspect.py
@@ -126,7 +126,7 @@ def create_introspect_schema_tool(db_url: str, engine: Engine | None = None):
                             lines.append("| " + " | ".join(col_names) + " |")
                             lines.append("| " + " | ".join(["---"] * len(col_names)) + " |")
                             for row in rows:
-                                vals = [str(v)[:30] if v else "NULL" for v in row]
+                                vals = ["NULL" if v is None else str(v)[:30] for v in row]
                                 lines.append("| " + " | ".join(vals) + " |")
                         else:
                             lines.append("_No data_")


### PR DESCRIPTION
## Problem

The sample-data renderer in `introspect_schema` formatted each cell with:

```python
vals = [str(v)[:30] if v else "NULL" for v in row]
```

`if v` is truthiness, so every **falsy** column value — `0`, `0.0`, `False`, empty string, `Decimal('0')` — was displayed as `NULL`. The agent reading the schema sample then sees missing data where real values exist.

## Reproduction

Running the real tool against a SQLite table with a row of `(0, '', 0, 0.0)`:

**Before**
```
| qty | name | flag | price |
| --- | --- | --- | --- |
| NULL | NULL | NULL | NULL |
| 5 | hello | 1 | 9.5 |
```

**After**
```
| qty | name | flag | price |
| --- | --- | --- | --- |
| 0 |  | 0 | 0.0 |
| 5 | hello | 1 | 9.5 |
```

## Fix

Treat only `None` as `NULL`; render every other value (including falsy ones) with `str(v)[:30]`:

```python
vals = ["NULL" if v is None else str(v)[:30] for v in row]
```