### PR TITLE
docs: refresh dash README to house style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,94 @@
-# Dash
+# Dash — a self-learning data agent
 
-A **self-learning data agent** built with systems engineering principles. It grounds answers in 6 layers of context and improves with every query.
+Ask a question in English, get a correct, meaningful answer. Raw LLMs writing SQL hit a wall fast: schemas lack meaning, tribal knowledge is missing, and there's no way to learn from mistakes. Dash solves this with layered, grounded context and a self-learning loop that improves with every query — built for teams that want a data agent they can trust with real analytics questions.
 
-Chat with Dash via Slack, the terminal, or the [AgentOS](https://os.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=agentos) web UI.
+## How it works
 
-## Quick Start
+Dash is a coordinated team of two agents behind [AgentOS](https://os.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=agentos) (`app/main.py`), backed by PostgreSQL + pgvector:
+
+- **Analyst** (`dash/agents/analyst.py`) — writes and runs SQL against company data (read-only), introspects schemas, and saves validated queries back to knowledge.
+- **Engineer** (`dash/agents/engineer.py`) — owns the agent-managed `dash` schema: views, summary tables, pipelines, and knowledge updates.
+- **Team leader** (`dash/team.py`) — routes requests, holds per-user memory, and (optionally) posts to Slack.
+
+**Grounded context** comes from five layers:
+
+| Layer | Purpose | Source |
+|-------|---------|--------|
+| Table usage | Schema, columns, relationships | `knowledge/tables/*.json` |
+| Human annotations | Metrics, definitions, business rules | `knowledge/business/*.json` |
+| Query patterns | SQL that is known to work | `knowledge/queries/*.sql` |
+| Learnings | Error patterns and discovered fixes | Agno Learning Machine |
+| Runtime context | Live schema changes | `introspect_schema` tool |
+
+**The self-learning loop:** every query retrieves knowledge + learnings before generating SQL. On errors, the agent diagnoses, fixes, and saves a learning so the mistake is never repeated. Validated queries can be saved back to knowledge.
+
+**Guardrails are infrastructure, not prompts:**
+
+| Schema | Owner | Enforcement |
+|--------|-------|-------------|
+| `public` | Company data | Analyst connects with `default_transaction_read_only=on`; a SQLAlchemy listener blocks Engineer writes to `public` |
+| `dash` | Engineer agent | Full SQL, scoped via `search_path` |
+
+## Quick start
+
+Requires Docker and an OpenAI API key.
 
 ```sh
-# Clone the repo
 git clone https://github.com/agno-agi/dash.git && cd dash
 
 cp example.env .env
 # Edit .env and add your OPENAI_API_KEY
 
-# Start the system
 docker compose up -d --build
 
-# Generate sample data and load knowledge
+# Generate the sample dataset and load knowledge
 docker exec -it dash-api python scripts/generate_data.py
 docker exec -it dash-api python scripts/load_knowledge.py
 ```
 
 Confirm Dash is running at [http://localhost:8000/docs](http://localhost:8000/docs).
 
-### Connect to the Web UI
-
-1. Open [os.agno.com](https://os.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=agentos) and login
-2. Add OS → Local → `http://localhost:8000`
-3. Click "Connect"
-
-**Try it** (SaaS metrics dataset):
+The sample dataset is a synthetic B2B SaaS company (~900 customers, 2 years of data: customers, subscriptions, plan changes, invoices, usage metrics, support tickets). Try:
 
 - What's our current MRR?
 - Which plan has the highest churn rate?
 - Show me revenue trends by plan over the last 6 months
 - Which customers are at risk of churning?
 
-## Deploy to Railway
+### Local development (without the API container)
 
-Railway deployment uses `.env.production` to keep production credentials separate from local dev.
+```sh
+./scripts/venv_setup.sh && source .venv/bin/activate
+docker compose up -d dash-db
+python scripts/generate_data.py
+python scripts/load_knowledge.py
+python -m dash          # terminal chat
+python -m app.main      # AgentOS server on :8000
+```
+
+## Interfaces
+
+- **AgentOS web UI** — open [os.agno.com](https://os.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=agentos), log in, then Add OS → Local → `http://localhost:8000` → Connect.
+- **Slack** — DMs, @mentions, and thread replies; each thread maps to one session. Set `SLACK_TOKEN` and `SLACK_SIGNING_SECRET`, give Dash a public URL, and follow [docs/SLACK_CONNECT.md](docs/SLACK_CONNECT.md) for the app manifest and setup.
+- **Terminal** — `python -m dash`.
+- **REST API** — FastAPI, with interactive docs at `/docs`.
+
+## Deploy
+
+Dash ships with Railway scripts (`railway.json` + `scripts/railway_*.sh`). Production notes:
+
+- The scheduler requires a **single replica** (`numReplicas: 1` in `railway.json`) — don't scale the app service horizontally.
+- Production boot (`RUNTIME_ENV=prd`, the default) enables authorization and **requires `JWT_VERIFICATION_KEY`**; the app crash-loops until it's set.
 
 ```sh
 cp example.env .env.production
 # Edit .env.production — set OPENAI_API_KEY
-```
 
-### Step 1: Deploy infrastructure
-
-This creates the Railway project, database, and app service. The app will crash-loop until the JWT key is added in the next step — that's expected.
-
-```sh
 railway login
-./scripts/railway_up.sh
+./scripts/railway_up.sh        # creates project, pgvector DB, app service, domain
 ```
 
-### Step 2: Get your JWT key
-
-Production requires a `JWT_VERIFICATION_KEY` from [AgentOS](https://os.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=agentos). You need the Railway domain from step 1 to set this up.
-
-1. Copy your Railway domain from the output of step 1 (e.g. `dash-production-xxxx.up.railway.app`)
-2. Open [os.agno.com](https://os.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=agentos) and login
-3. Add OS → Live → paste your Railway URL
-4. Go to **Settings** and generate a key pair
-5. Add the public key to `.env.production` (wrap in single quotes):
+Then get your JWT key: open [os.agno.com](https://os.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=agentos) → Add OS → Live → paste your Railway URL → Settings → generate a key pair. Add the public key to `.env.production` (single quotes, including the BEGIN/END lines):
 
 ```bash
 JWT_VERIFICATION_KEY='-----BEGIN PUBLIC KEY-----
@@ -70,309 +96,67 @@ MIIBIjANBgkq...
 -----END PUBLIC KEY-----'
 ```
 
-### Step 3: Push environment and redeploy
+Push the environment and redeploy:
 
 ```sh
-./scripts/railway_env.sh
+./scripts/railway_env.sh       # syncs .env.production → Railway (idempotent, handles PEM keys)
 ./scripts/railway_redeploy.sh
 ```
 
-`railway_env.sh` reads `.env.production` and sets each variable on the Railway service. Safe to run repeatedly. Handles multiline values (PEM keys) correctly.
-
-### Production operations
-
-Database scripts must run inside Railway's network (the internal hostname `pgvector.railway.internal` isn't reachable from your local machine). Use SSH to connect to the running container:
+Database scripts must run inside Railway's network (the internal hostname isn't reachable locally):
 
 ```sh
 railway ssh --service dash
-# Inside the container:
+# inside the container:
 python scripts/generate_data.py
 python scripts/load_knowledge.py
 ```
 
-Other operations run locally:
+## Configuration
 
-```sh
-railway logs --service dash
-railway open
-```
-
-## Why Dash Exists
-
-Ask a question in English, get a correct, meaningful answer. That's the goal. But raw LLMs writing SQL hit a wall fast: schemas lack meaning, types are misleading, tribal knowledge is missing, there's no way to learn from mistakes, and results lack interpretation.
-
-The root cause is missing context and missing memory. Dash solves this with **six layers of grounded context**, a **self-learning loop** that improves with every query, and a focus on delivering insights you can act on.
-
-## Architecture: Five Layers, One System
-
-Agentic software is just software with the business logic replaced by agents. Everything else is systems engineering. Dash is built across five layers that reinforce each other.
-
-```
-Agent Engineering     →  dash/team.py + dash/agents/
-Data Engineering      →  knowledge/ + Agno Learning Machine + PostgreSQL
-Security Engineering  →  AgentOS auth + RBAC + read-only SQL enforcement
-Interface Engineering →  app/main.py (FastAPI) + Slack + AgentOS
-Infrastructure        →  Dockerfile + compose.yaml + scripts/
-```
-
-### 1. Agent Engineering
-
-The agent team and execution flow. Model, instructions, tools, knowledge, and the self-learning loop.
-
-```
-AgentOS (app/main.py)  [scheduler=True, tracing=True]
- ├── FastAPI / Uvicorn
- ├── Slack Interface (optional)
- └── Dash Team (dash/team.py, coordinate mode)
-     ├─ Analyst (dash/agents/analyst.py)         reads public + dash
-     │  ├─ SQLTools (read-only)  → public schema (company data)
-     │  ├─ introspect_schema     → both schemas
-     │  ├─ save_validated_query  → knowledge base
-     │  └─ ReasoningTools
-     ├─ Engineer (dash/agents/engineer.py)       reads public, writes dash
-     │  ├─ SQLTools (full)       → dash schema (agent-managed)
-     │  ├─ introspect_schema     → both schemas
-     │  ├─ update_knowledge      → knowledge base (schema changes)
-     │  └─ ReasoningTools
-     │
-     Leader tools: SlackTools (optional)
-     Knowledge:    dash_knowledge (table schemas, queries, business rules, dash views)
-     Learnings:    dash_learnings (error patterns, type gotchas, fixes)
-```
-
-### 2. Data Engineering
-
-Context is data. Memory is data. Knowledge is data. All managed with data engineering principles: well-designed schemas, structured querying, databases for fast read/writes.
-
-**Six layers of grounded context:**
-
-| Layer | Purpose | Source |
-|------|--------|--------|
-| **Table Usage** | Schema, columns, relationships | `knowledge/tables/*.json` |
-| **Human Annotations** | Metrics, definitions, business rules | `knowledge/business/*.json` |
-| **Query Patterns** | SQL that is known to work | `knowledge/queries/*.sql` |
-| **Institutional Knowledge** | Docs, wikis, external references | MCP (optional) |
-| **Learnings** | Error patterns and discovered fixes | Agno `Learning Machine` |
-| **Runtime Context** | Live schema changes | `introspect_schema` tool |
-
-**The self-learning loop:**
-
-```
-User Question
-     ↓
-Retrieve Knowledge + Learnings
-     ↓
-Reason about intent
-     ↓
-Generate grounded SQL
-     ↓
-Execute and interpret
-     ↓
- ┌────┴────┐
- ↓         ↓
-Success    Error
- ↓         ↓
- ↓         Diagnose → Fix → Save Learning
- ↓                           (never repeated)
- ↓
-Return insight
- ↓
-Optionally save as Knowledge
-```
-
-Two complementary systems:
-
-| System | Stores | How It Evolves |
-|------|--------|----------------|
-| **Knowledge** | Validated queries and business context | Curated by you + Dash |
-| **Learnings** | Error patterns and fixes | Managed by `Learning Machine` automatically |
-
-**Dual schema enforcement:** A structural boundary between company data and agent-managed data.
-
-| Schema | Owner | Access |
-|--------|-------|--------|
-| `public` | Company (loaded externally) | Read-only — never modified by agents |
-| `dash` | Engineer agent | Views, summary tables, computed data |
-
-The Engineer builds reusable data assets (`dash.monthly_mrr`, `dash.customer_health_score`, `dash.churn_risk`) and records them to knowledge. The Analyst discovers and prefers these views over raw table queries.
-
-### 3. Security Engineering
-
-Auth uses RBAC with JWT verification in production. Every query is scoped to `user_id`. Read-only access is a tool configuration, not a prompt instruction. The Analyst agent's SQL tools are scoped to read-only at the system level.
-
-See [Security](#security) for setup details.
-
-### 4. Interface Engineering
-
-One agent definition, multiple surfaces. Dash is reachable via REST API (FastAPI), Slack threads, and the AgentOS web UI. Each surface has its own identity system: a Slack user ID maps to sessions via thread timestamps, the API uses JWT-backed auth.
-
-### 5. Infrastructure Engineering
-
-Dockerfile, Docker Compose, one-command deployment. Scheduled tasks for proactive behavior. The infrastructure layer is boring on purpose. 95% of running an agent is identical to running any other service.
-
-## Slack
-
-Dash can receive Slack DMs, @mentions, and thread replies, and can also post to channels proactively.
-
-Quick setup:
-1. Run Dash and give it a public URL (ngrok locally, or your Railway domain).
-2. Follow [docs/SLACK_CONNECT.md](docs/SLACK_CONNECT.md) to create and install the Slack app from the manifest.
-3. Set `SLACK_TOKEN` and `SLACK_SIGNING_SECRET`, then restart Dash.
-4. In Slack, confirm Event Subscriptions is verified and send a DM or `@mention` to test it.
-
-Each Slack thread maps to one Dash session. For the manifest, ngrok commands, Railway deployment, permissions, and troubleshooting, see [docs/SLACK_CONNECT.md](docs/SLACK_CONNECT.md).
-
-## Data Model (SaaS Metrics)
-
-Synthetic B2B SaaS dataset (~900 customers, 2 years of data):
-
-| Table | Description |
-|-------|-------------|
-| `customers` | Company info, industry, size, acquisition source, status |
-| `subscriptions` | Plan, MRR, seats, billing cycle, lifecycle status |
-| `plan_changes` | Upgrades, downgrades, cancellations with MRR impact |
-| `invoices` | Billing records, payment status, billing periods |
-| `usage_metrics` | Daily API calls, active users, storage, reports |
-| `support_tickets` | Priority, category, resolution time, satisfaction |
-
-## Adding Knowledge
-
-Dash works best when it understands how your organization talks about data.
-
-```
-knowledge/
-├── tables/      # Table meaning and caveats
-├── queries/     # Proven SQL patterns
-└── business/    # Metrics and language
-```
-
-### Table Metadata
-
-```json
-{
-  "table_name": "customers",
-  "table_description": "B2B SaaS customer accounts with company info and lifecycle status",
-  "use_cases": ["Churn analysis", "Cohort segmentation", "Acquisition reporting"],
-  "data_quality_notes": [
-    "signup_date is DATE (not TIMESTAMP) — no time component",
-    "status values: active, churned, trial",
-    "company_size is self-reported"
-  ]
-}
-```
-
-### Query Patterns
-
-```sql
--- <query monthly_mrr>
--- <description>Monthly MRR from active subscriptions</description>
--- <query>
-SELECT
-    DATE_TRUNC('month', started_at) AS month,
-    SUM(mrr) AS total_mrr
-FROM subscriptions
-WHERE ended_at IS NULL
-GROUP BY 1
-ORDER BY 1 DESC
--- </query>
-```
-
-### Business Rules
-
-```json
-{
-  "metrics": [
-    {
-      "name": "MRR",
-      "definition": "Sum of active subscriptions excluding trials"
-    }
-  ],
-  "common_gotchas": [
-    {
-      "issue": "Active subscription detection",
-      "solution": "Filter on ended_at IS NULL, not status column"
-    }
-  ]
-}
-```
-
-### Load Knowledge
-
-```sh
-python scripts/load_knowledge.py            # Upsert changes
-python scripts/load_knowledge.py --recreate  # Fresh start
-```
-
-## Evaluations
-
-Five eval categories using Agno's eval framework:
-
-| Category | Eval Type | What It Tests |
-|----------|-----------|---------------|
-| accuracy | AccuracyEval (1-10) | Correct data and meaningful insights |
-| routing | ReliabilityEval | Team routes to correct agent/tools |
-| security | AgentAsJudgeEval (binary) | No credential or secret leaks |
-| governance | AgentAsJudgeEval (binary) | Refuses destructive SQL operations |
-| boundaries | AgentAsJudgeEval (binary) | Schema access boundaries respected |
-
-```sh
-python -m evals                      # Run all evals
-python -m evals --category accuracy  # Run specific category
-python -m evals --verbose            # Show response details
-```
-
-## Local Development
-
-```sh
-./scripts/venv_setup.sh && source .venv/bin/activate
-docker compose up -d dash-db
-python scripts/generate_data.py
-python scripts/load_knowledge.py
-python -m dash            # CLI mode
-python -m app.main        # AgentOS mode (web UI at os.agno.com)
-```
-
-## Environment Variables
+Set in `.env` (local) or `.env.production` (Railway). See [example.env](example.env).
 
 | Variable | Required | Default | Purpose |
 |----------|----------|---------|---------|
 | `OPENAI_API_KEY` | Yes | — | OpenAI API key |
-| `SLACK_TOKEN` | No | `""` | Slack bot token (interface + tools) |
-| `SLACK_SIGNING_SECRET` | No | `""` | Slack signing secret (interface only) |
-| `DB_HOST` | No | `localhost` | PostgreSQL host |
-| `DB_PORT` | No | `5432` | PostgreSQL port |
-| `DB_USER` | No | `ai` | PostgreSQL user |
-| `DB_PASS` | No | `ai` | PostgreSQL password |
-| `DB_DATABASE` | No | `ai` | PostgreSQL database |
-| `PORT` | No | `8000` | API port |
-| `RUNTIME_ENV` | No | `prd` | `dev` enables hot reload |
-| `AGENTOS_URL` | No | `http://127.0.0.1:8000` | Scheduler callback URL (production) |
+| `SLACK_TOKEN` | No | `""` | Slack bot token (interface + leader tools) |
+| `SLACK_SIGNING_SECRET` | No | `""` | Slack signing secret (interface) |
+| `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASS` / `DB_DATABASE` | No | `localhost` / `5432` / `ai` / `ai` / `ai` | PostgreSQL connection (compose sets these) |
+| `RUNTIME_ENV` | No | `prd` | `dev` disables auth and enables hot reload (compose sets `dev`) |
+| `AGENTOS_URL` | No | `http://127.0.0.1:8000` | Scheduler callback URL (set to your public URL in production) |
 | `JWT_VERIFICATION_KEY` | Production | — | RBAC public key from [os.agno.com](https://os.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=agentos) |
 
-## Security
+### Adding knowledge
 
-Production deployments require authentication via [Agno AgentOS](https://docs.agno.com/agent-os/security/overview?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=security). Dash enables [RBAC authorization](https://docs.agno.com/agent-os/security/rbac?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=rbac) when `RUNTIME_ENV=prd` (the default). Without a valid `JWT_VERIFICATION_KEY`, production endpoints will reject all requests.
+Dash works best when it understands how your organization talks about data. Drop files into `knowledge/tables/` (table meaning and caveats, JSON), `knowledge/queries/` (proven SQL patterns), and `knowledge/business/` (metrics and business rules, JSON), then load:
 
-Local development (`RUNTIME_ENV=dev`, set by Docker Compose) runs without auth so you can iterate freely.
+```sh
+python scripts/load_knowledge.py             # upsert changes
+python scripts/load_knowledge.py --recreate  # fresh start
+```
 
-### Auth Setup
+A daily scheduled task (`knowledge-refresh`, 04:00 UTC) re-indexes knowledge files automatically.
 
-See [Deploy to Railway](#deploy-to-railway) for the full setup flow, including how to get your `JWT_VERIFICATION_KEY` from AgentOS. The Agno control plane handles JWT issuance, session management, traces, metrics, and the web UI. See the [AgentOS Security docs](https://docs.agno.com/agent-os/security/overview?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=security) for details.
+## Evals
 
-### Schema-Level Enforcement
+Five categories using Agno's eval framework — accuracy (AccuracyEval), routing (ReliabilityEval), and security / governance / boundaries (AgentAsJudgeEval, binary). Requires the venv and a running database:
 
-Beyond API-level auth, Dash enforces data access at the database level:
+```sh
+python -m evals                      # run all categories
+python -m evals --category accuracy  # one category
+python -m evals --verbose            # show response details
 
-- **Analyst** connects with `default_transaction_read_only=on` — PostgreSQL rejects any write attempt
-- **Engineer** writes are scoped to the `dash` schema — a SQLAlchemy event listener blocks any DDL/DML targeting `public`
-- **Leader** has no direct database access
+python -m evals smoke                # lightweight smoke tests
+python -m evals improve --dry-run    # self-improvement loop (analyze only)
+```
 
-These are infrastructure guardrails, not prompt instructions. They hold regardless of what the model generates.
+See [docs/TEST_QUESTIONS.md](docs/TEST_QUESTIONS.md) for probing questions and [docs/IMPROVE_DASH.md](docs/IMPROVE_DASH.md) for the agent-driven improvement loop.
 
-## Learn More
+## Source / links
 
-- [OpenAI's In-House Data Agent](https://openai.com/index/inside-our-in-house-data-agent/) — the inspiration
-- [Self-Improving SQL Agent](https://www.ashpreetbedi.com/articles/sql-agent) — deep dive on an earlier architecture
-- [Agno Docs](https://docs.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=docs)
+- [Contributing guide](CONTRIBUTING.md) — dev setup, `./scripts/format.sh`, `./scripts/validate.sh`
+- [OpenAI's in-house data agent](https://openai.com/index/inside-our-in-house-data-agent/) — the inspiration
+- [Self-improving SQL agent](https://www.ashpreetbedi.com/articles/sql-agent) — deep dive on an earlier architecture
+- [Agno docs](https://docs.agno.com?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=docs) · [AgentOS security](https://docs.agno.com/agent-os/security/overview?utm_source=github&utm_medium=example-repo&utm_campaign=agent-example&utm_content=dash&utm_term=security)
 
 <p align="center">Built on <a href="https://github.com/agno-agi/agno">Agno</a> · the runtime for agentic software</p>


### PR DESCRIPTION
## Summary

Docs-only refresh of README.md to the house style (tagline → intro → How it works → Quick start → Interfaces → Deploy → Configuration → Evals → Links). Every command was verified against the current code (compose.yaml, scripts/, app/main.py, evals/__main__.py, example.env, railway.json). No code changes.

### Changes
- Restructured to the house-style section order; cut the long five-layer engineering essay into a short "How it works" (agents, context layers, learning loop, schema guardrails) — all claims verified against `dash/team.py`, `dash/agents/`, `db/session.py`, `dash/tools/build.py`.
- **Removed the "Institutional Knowledge — MCP (optional)" context layer row**: nothing in the codebase wires MCP, and agno's built-in MCP server supersedes manual MCP setup. Context table is now five verified layers.
- **Removed the unused `PORT` env var from the configuration table** — nothing reads it; port 8000 is hardcoded in compose.yaml and railway.json `startCommand`.
- Deploy section now explicitly notes the **single-replica scheduler constraint** (`numReplicas: 1` in railway.json) and that **production boot requires `JWT_VERIFICATION_KEY`** (authorization is enabled when `RUNTIME_ENV=prd`, the default; app crash-loops until the key is set).
- Evals section now documents the actual CLI surface from `evals/__main__.py`: `--category`, `--verbose`, plus the `smoke` and `improve` subcommands (previously undocumented).
- Documented the `knowledge-refresh` daily scheduled task (04:00 UTC) registered in `app/main.py`.
- Kept verified Railway flow (`railway_up.sh` → JWT key → `railway_env.sh` → `railway_redeploy.sh`, `railway ssh --service dash` for in-network data scripts), Slack pointer to docs/SLACK_CONNECT.md, and quick-start commands unchanged in substance.
- CONTRIBUTING.md and docs/*.md checked — accurate as-is, no changes needed.

### Non-doc issues spotted (NOT changed — for reviewer)
- `pyproject.toml` lists `mcp` as a dependency but nothing in the codebase imports it; likely removable (belongs in the dependency-bump PR, not this docs PR).
- `compose.yaml`/`railway.json` hardcode port 8000 while old README implied a `PORT` env var; if configurable port is desired, that's a code change.

Orthogonal to the open `chore/update-*` bump PR; contains no version or code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)